### PR TITLE
Adds support for asciidoc

### DIFF
--- a/lib/click-link.js
+++ b/lib/click-link.js
@@ -16,6 +16,8 @@ export default {
             }
 
             var isMarkdown = editor.getGrammar().scopeName == "source.gfm"
+            var isAsciidoc = editor.getGrammar().scopeName == "source.asciidoc"
+
             /*
             * Does the link have a hyperlink class
             * If so, it doesn't matter if this is a markdown file or not
@@ -38,20 +40,25 @@ export default {
                         element = path;
                         break;
                     }
-                    else if(isMarkdown && path.classList.contains("syntax--link") > 0) {
-                        var child = path.querySelector(".syntax--link");
+                    else if(path.classList.contains("syntax--link") > 0) {
+                        if (isMarkdown){
+                            var child = path.querySelector(".syntax--link");
 
-                        /*
-                        * Markdown links can have the following structure
-                        * [name](url) both the whole construct as well as the url
-                        * (with the parentheses) have the link class
-                        * If the clicked element with the link class has a child
-                        * that has also the link class, we have clicked somewhere
-                        * around "[name]" but since we search for a child with the
-                        * link class, element will always be the element containing
-                        * "(url)"
-                        */
-                        element = child? child : path;
+                            /*
+                            * Markdown links can have the following structure
+                            * [name](url) both the whole construct as well as the url
+                            * (with the parentheses) have the link class
+                            * If the clicked element with the link class has a child
+                            * that has also the link class, we have clicked somewhere
+                            * around "[name]" but since we search for a child with the
+                            * link class, element will always be the element containing
+                            * "(url)"
+                            */
+                            element = child? child : path;
+                        } 
+                        else if (isAsciidoc){
+                            element = path;
+                        }
 
                         break;
                     }

--- a/styles/click-link.less
+++ b/styles/click-link.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-atom-text-editor.editor .syntax--hyperlink:hover, atom-text-editor.editor .syntax--source.syntax--gfm .syntax--link:hover {
+atom-text-editor.editor .syntax--hyperlink:hover, atom-text-editor.editor .syntax--source.syntax--gfm .syntax--link:hover, atom-text-editor.editor .syntax--source.syntax--asciidoc .syntax--link:hover {
     text-decoration: underline;
     cursor: pointer;
 }


### PR DESCRIPTION
Adds support for links in asciidoc document if the [language-asciidoc](https://atom.io/packages/language-asciidoc) package is used.